### PR TITLE
Fix Erroneous IPA for "you" and "yong"

### DIFF
--- a/dragonmapper/data/transcriptions.csv
+++ b/dragonmapper/data/transcriptions.csv
@@ -369,8 +369,8 @@ ye,ㄧㄝ,jɛ
 yi,ㄧ,i
 yin,ㄧㄣ,in
 ying,ㄧㄥ,iŋ
-yong,ㄩㄥ,yʊŋ
-you,ㄧㄡ,yoʊ
+yong,ㄩㄥ,jʊŋ
+you,ㄧㄡ,joʊ
 yu,ㄩ,y
 yuan,ㄩㄢ,ɥœn
 yue,ㄩㄝ,ɥœ


### PR DESCRIPTION
Fixes #25. See [this](https://en.wikipedia.org/wiki/Pinyin#Comparison_charts) for correct phonemes for *you* and *yong*